### PR TITLE
Fix MetaCoq utils imports

### DIFF
--- a/tests/theories/ElmExtractExamples.v
+++ b/tests/theories/ElmExtractExamples.v
@@ -19,7 +19,7 @@ From ElmExtraction.Tests Require Import Ack.
 From MetaCoq.Common Require Import Kernames.
 From MetaCoq.Template Require Import Ast.
 From MetaCoq.Template Require Import TemplateMonad.
-From MetaCoq Require Import utils.
+From MetaCoq.Utils Require Import utils.
 From Coq Require Import String.
 
 Import MCMonadNotation.

--- a/tests/theories/ElmExtractTests.v
+++ b/tests/theories/ElmExtractTests.v
@@ -9,7 +9,7 @@ From ElmExtraction Require Import StringExtra.
 From MetaCoq.Common Require Import Kernames.
 From MetaCoq.Template Require Import Ast.
 From MetaCoq.Template Require Import TemplateMonad.
-From MetaCoq Require Import utils.
+From MetaCoq.Utils Require Import utils.
 From Coq Require Import String.
 
 Local Open Scope string.

--- a/tests/theories/ElmForms.v
+++ b/tests/theories/ElmForms.v
@@ -17,7 +17,7 @@ From ElmExtraction.Tests Require Import RecordUpdate.
 From MetaCoq.Common Require Import Kernames.
 From MetaCoq.Template Require Import Ast.
 From MetaCoq.Template Require Import TemplateMonad.
-From MetaCoq Require Import utils.
+From MetaCoq.Utils Require Import utils.
 From Coq Require Import ssrbool.
 From Coq Require Import String.
 


### PR DESCRIPTION
Building fails when coq-metacoq-quotation is installed because the import statement `From MetaCoq Require Import utils` isn't specific enough.

Fixes #7 